### PR TITLE
chore: pin external GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,8 @@ jobs:
       matrix:
         node: [14]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: ${{ matrix.node }}
       - run: node --version

--- a/.github/workflows/conventional-label.yaml
+++ b/.github/workflows/conventional-label.yaml
@@ -6,4 +6,4 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: bcoe/conventional-release-labels@v1
+      - uses: bcoe/conventional-release-labels@886f696738527c7be444262c327c89436dfb95a8 # v1

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: install
       run: npm ci
     - name: build
@@ -42,7 +42,7 @@ jobs:
         echo "${DIFF}" >> $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV
     - name: Create PR with dist
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 # v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: Build dist
@@ -59,7 +59,7 @@ jobs:
     needs: [build]
     steps:
       - id: release-pr
-        uses: GoogleCloudPlatform/release-please-action@main
+        uses: GoogleCloudPlatform/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node
@@ -67,7 +67,7 @@ jobs:
           command: release-pr
       - id: label
         if: ${{ steps.release-pr.outputs.pr }}
-        uses: actions/github-script@v3
+        uses: actions/github-script@ffc2c79a5b2490bd33e0a41c1de74b877714d736 # v3
         with:
             github-token: ${{secrets.GITHUB_TOKEN}}
             script: |
@@ -83,14 +83,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@main
+      - uses: GoogleCloudPlatform/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # main
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: node
           package-name: ${{env.ACTION_NAME}}
           command: github-release
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: tag major and patch versions
         run: |
           git config user.name github-actions[bot]


### PR DESCRIPTION
## Summary

- Pin all unpinned external GitHub Action `uses:` references to full 40-character commit SHAs
- Original version tags/branches preserved as inline comments for maintainability
- No other CI changes included

## Motivation

Supply chain security hardening: pinning actions to immutable commit SHAs prevents silent changes from compromised or force-pushed tags.

Part of the org-wide audit tracked in [SEC-6683](https://linear.app/phantom-labs/issue/SEC-6683) and [SEC-7928](https://linear.app/phantom-labs/issue/SEC-7928).

## Test plan

- [ ] CI passes on this branch
- [ ] Verify pinned SHAs match the expected versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)